### PR TITLE
feat: feature request intake — submit, list, triage tools

### DIFF
--- a/config/prompts/capabilities/feature-requests.md
+++ b/config/prompts/capabilities/feature-requests.md
@@ -1,0 +1,7 @@
+**Feature Requests** — Household members can suggest new capabilities or improvements.
+---
+- When someone says "I wish you could...", "feature request:", "it would be nice if...", "can you add...", or similar, use feature_request to log it.
+- Respond warmly after logging. Don't promise timelines or speculate on feasibility.
+- Don't prompt people to submit feature requests. Only capture them when volunteered.
+- Lee can use feature_request_list and feature_request_triage to review and act on requests.
+- When triaging with notify_requester: true, compose a natural Signal DM using message_send to tell the requester what happened. Sound like Iji, not a ticket system.

--- a/src/brain/prompt.js
+++ b/src/brain/prompt.js
@@ -20,6 +20,7 @@ const capabilityFiles = {
   email: 'email.md',
   sms: 'sms.md',
   reminders: 'reminders.md',
+  'feature-requests': 'feature-requests.md',
 };
 
 const CAPABILITY_TRIGGERS = {

--- a/src/tools/feature-request-list.js
+++ b/src/tools/feature-request-list.js
@@ -1,0 +1,32 @@
+import { getDb } from '../utils/db.js';
+
+export const definition = {
+  name: 'feature_request_list',
+  description: 'List feature requests. Admin only. Defaults to showing new/unreviewed requests.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      status: {
+        type: 'string',
+        description: 'Filter by status: new, accepted, declined, merged, built. Default: new',
+      },
+    },
+  },
+};
+
+export async function execute(input, envelope) {
+  if (envelope.role !== 'admin') {
+    return { error: 'Only admins can view feature requests.' };
+  }
+
+  const db = getDb();
+  const status = input?.status || 'new';
+
+  const rows = db
+    .prepare(
+      'SELECT id, requester_id, request_text, status, triage_notes, created_at, triaged_at FROM feature_requests WHERE status = ? ORDER BY created_at DESC'
+    )
+    .all(status);
+
+  return { requests: rows, count: rows.length };
+}

--- a/src/tools/feature-request-triage.js
+++ b/src/tools/feature-request-triage.js
@@ -1,0 +1,66 @@
+import { getDb } from '../utils/db.js';
+
+export const definition = {
+  name: 'feature_request_triage',
+  description: 'Triage a feature request — accept, decline, merge, or mark as built. Admin only. Optionally notify the requester via Signal DM.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      id: {
+        type: 'integer',
+        description: 'Feature request ID',
+      },
+      status: {
+        type: 'string',
+        description: 'New status: accepted, declined, merged, built',
+      },
+      triage_notes: {
+        type: 'string',
+        description: 'Reasoning for the decision',
+      },
+      notify_requester: {
+        type: 'boolean',
+        description: 'Send a Signal DM to the requester about the decision. Default: false',
+      },
+    },
+    required: ['id', 'status'],
+  },
+};
+
+const VALID_STATUSES = ['new', 'accepted', 'declined', 'merged', 'built'];
+
+export async function execute(input, envelope) {
+  if (envelope.role !== 'admin') {
+    return { error: 'Only admins can triage feature requests.' };
+  }
+
+  if (!VALID_STATUSES.includes(input.status)) {
+    return { error: `Invalid status: ${input.status}. Must be one of: ${VALID_STATUSES.join(', ')}` };
+  }
+
+  const db = getDb();
+
+  const existing = db
+    .prepare('SELECT * FROM feature_requests WHERE id = ?')
+    .get(input.id);
+
+  if (!existing) {
+    return { error: `Feature request ${input.id} not found.` };
+  }
+
+  db.prepare(
+    'UPDATE feature_requests SET status = ?, triage_notes = ?, triaged_at = datetime(\'now\') WHERE id = ?'
+  ).run(input.status, input.triage_notes || null, input.id);
+
+  const result = { updated: true, id: input.id, status: input.status };
+
+  if (input.notify_requester) {
+    result.notify = {
+      requester_id: existing.requester_id,
+      request_text: existing.request_text,
+      new_status: input.status,
+    };
+  }
+
+  return result;
+}

--- a/src/tools/feature-request.js
+++ b/src/tools/feature-request.js
@@ -1,0 +1,28 @@
+import { getDb } from '../utils/db.js';
+
+export const definition = {
+  name: 'feature_request',
+  description: 'Log a feature request or suggestion from a household member. Use when someone says "I wish you could...", "feature request:", "it would be nice if...", "can you add...", or similar.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      request: {
+        type: 'string',
+        description: 'What the person wants Iji to be able to do',
+      },
+    },
+    required: ['request'],
+  },
+};
+
+export async function execute(input, envelope) {
+  const db = getDb();
+
+  const result = db
+    .prepare(
+      'INSERT INTO feature_requests (requester_id, request_text) VALUES (?, ?)'
+    )
+    .run(envelope.person, input.request);
+
+  return { submitted: true, id: result.lastInsertRowid };
+}

--- a/src/tools/index.js
+++ b/src/tools/index.js
@@ -18,6 +18,9 @@ import * as smsSend from './sms-send.js';
 import * as reminderSet from './reminder-set.js';
 import * as reminderList from './reminder-list.js';
 import * as reminderUpdate from './reminder-update.js';
+import * as featureRequest from './feature-request.js';
+import * as featureRequestList from './feature-request-list.js';
+import * as featureRequestTriage from './feature-request-triage.js';
 import { checkPermission } from '../utils/permissions.js';
 import log from '../utils/logger.js';
 
@@ -42,6 +45,9 @@ const tools = {
   reminder_set: reminderSet,
   reminder_list: reminderList,
   reminder_update: reminderUpdate,
+  feature_request: featureRequest,
+  feature_request_list: featureRequestList,
+  feature_request_triage: featureRequestTriage,
 };
 
 export function getToolDefinitions() {

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -123,6 +123,19 @@ function migrate(db) {
     )
   `);
 
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS feature_requests (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      requester_id TEXT NOT NULL,
+      request_text TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'new',
+      triage_notes TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      triaged_at TEXT
+    )
+  `);
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_feature_requests_status ON feature_requests(status)`);
+
   const seedGroup = db.prepare(
     'INSERT OR IGNORE INTO signal_groups (group_id, group_name) VALUES (?, ?)'
   );

--- a/src/utils/morning-briefing.js
+++ b/src/utils/morning-briefing.js
@@ -84,6 +84,25 @@ async function runMorningBriefingCycle() {
       continue;
     }
 
+    let featureRequestsLine = '';
+    if (member.role === 'admin') {
+      try {
+        const db = getDb();
+        const row = db
+          .prepare(`SELECT COUNT(*) as count FROM feature_requests WHERE status = 'new'`)
+          .get();
+        const count = Number(row?.count || 0);
+        if (count > 0) {
+          featureRequestsLine = `\n5. 📋 ${count} new feature request${count > 1 ? 's' : ''} to review.`;
+        }
+      } catch (err) {
+        log.warn('Morning briefing feature request count failed', {
+          person_id: personId,
+          error: err.message,
+        });
+      }
+    }
+
     const envelope = {
       person_id: personId,
       person: member.display_name,
@@ -96,6 +115,7 @@ Check the following and include anything noteworthy:
 2. Current weather and today's forecast — mention only if it affects plans or is notable.
 3. Pending reminders due today or overdue.
 4. Anything stored in household knowledge in the last 24 hours that's relevant to them.
+${featureRequestsLine}
 
 Keep it concise — this is a Signal message, not an email. Lead with the most important item. Skip sections with nothing noteworthy (don't say "no reminders" — just omit). Write like a Chief of Staff giving a 30-second verbal briefing.`,
       source_channel: 'signal',


### PR DESCRIPTION
## Summary
- add `feature_requests` SQLite table + status index migration
- add `feature_request`, `feature_request_list` (admin), and `feature_request_triage` (admin) tools
- register feature-request capability prompt and include pending new-request count in admin morning briefing

## Notes
- kept feature request tools out of `TOOL_PERMISSIONS` per spec; list/triage enforce admin role internally

Made with [Cursor](https://cursor.com)