### PR TITLE
Add Finances Phase 1: account balances and budget tools

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -9,7 +9,7 @@ The backlog is the single source of truth for what to build and fix.
 | Scheduling & Coordination | 7 | 0 | 0 | 3 |
 | Communication | 3 | 0 | 1 | 4 |
 | Email & Documents | 2 | 0 | 1 | 5 |
-| Finances | 3 | 0 | 0 | 3 |
+| Finances | 3 | 0 | 3 | 1 |
 | Home Operations | 4 | 0 | 0 | 11 |
 | Meals & Kitchen | 0 | 0 | 0 | 5 |
 | Children | 0 | 0 | 0 | 4 |
@@ -49,7 +49,7 @@ Status legend: ✅ Verified / 🔧 Fix pending / ⚠️ Untested / ❌ Not built
 | Signal inbound/outbound assistant | `src/broker/signal.js`, `src/router/signal.js` | ✅ Verified | Household on Signal | High | Core channel working in production |
 | Relay/announce to people and groups | `message_send` | ✅ Verified | Adults (`message_send`) | High | Uses Signal + group registry (`signal_groups`) |
 | Delivery confirmation correctness | `message_send` | ✅ Verified | Adults | High | Tool now returns send failure when Signal TCP client is unavailable |
-| Slack channel adapter | not built | ❌ Not built | Not rolled out | Medium | Architecture supports it; implementation pending |
+| Slack channel adapter | not built | ❌ Not built | Not rolled out | Medium | Architecture supports it; implementation pending. Prerequisite for Finances capability across all channels (currently Signal + CLI only). |
 | Slack message search | `slack_search` (not built) | ❌ Not built | Not rolled out | Medium | Needs Slack API integration + auth |
 | SMS channel for non-Signal contacts | `sms_send` | ⚠️ Deployed, awaiting Twilio verification | Lee first, then rollout | High | Twilio REST API (no SDK). External contacts registry in `config/contacts.json`. Toll-free number purchased, awaiting carrier verification (1-3 business days). Spec: `specs/SMS-SEND.md`. Decision: `docs/decisions/2026-02-26-outbound-comms-rollout.md`. |
 | Email as a channel (inbound/outbound) | not built | ❌ Not built | Not rolled out | Medium | Distinct from Gmail search/read tools |
@@ -75,8 +75,9 @@ Status legend: ✅ Verified / 🔧 Fix pending / ⚠️ Untested / ❌ Not built
 | Query transactions | `finance_transactions` | ✅ Verified | Lee only (`financial` permission) | High | Verified on EC2 with current Monarch auth/session setup |
 | Payback ledger visibility | `finance_paybacks` | ✅ Verified | Lee only (`financial`) | High | Verified expected behavior: returns "not configured" when state file is absent; no hardcoded Mac path |
 | Cost/usage visibility for Iji | `cost_query` | ✅ Verified | Lee only (`financial`) | Medium | Reads `claude_usage` in SQLite |
-| Account balances snapshot | `finance_balances` (not built) | ❌ Not built | Not rolled out | Medium | Planned Monarch-derived capability |
-| Budget tracking by category | `finance_budget` (not built) | ❌ Not built | Not rolled out | Medium | Planned Monarch-derived capability |
+| Account balances snapshot | `finance_accounts` | ⚠️ Untested | Lee only (`financial`) | High | Phase 1 Finances capability. Wraps `monarch.getAccounts()`. Spec: `specs/finances/FINANCES-CAPABILITY.md` |
+| Budget tracking by category | `finance_budget_summary` | ⚠️ Untested | Lee only (`financial`) | High | Phase 1 Finances capability. New `getBudgets()` GraphQL query. Spec: `specs/finances/FINANCES-CAPABILITY.md` |
+| Financial reasoning (prompt) | system prompt | ⚠️ Untested | Lee only (`financial`) | High | Phase 1. Capability prompt with tax context, equity withholding reasoning, advisor tone. |
 | Bill due reminders | not built | ❌ Not built | Not rolled out | Low | Proactive feature from status/backlog |
 
 ## 5) 🏠 Home Operations

--- a/config/prompts/capabilities/finance.md
+++ b/config/prompts/capabilities/finance.md
@@ -1,3 +1,33 @@
-
+**Finances & Accounts** — I have access to the household's real financial data via Monarch Money. I can look up account balances, check budget health, search transactions, and reason about spending patterns, net worth, and tax implications like an experienced financial advisor.
 ---
+## Finance tools
 
+- **finance_accounts** — Snapshot of all accounts (checking, savings, investments, 529s, credit cards, loans) with current balances. Use for "how much cash do we have", "what's our net worth", "how are the 529s doing".
+- **finance_budget_summary** — Budget vs. actual spend for a given month, broken down by category. Use for "how are we doing on the budget", "where can we trim", "what's our burn rate".
+- **finance_transactions** — Search transactions by date range, merchant, category, or account. Use for "how much did we spend at Costco", "show dining expenses last month".
+- **finance_paybacks** — Household payback ledger showing who owes whom among adults.
+- **cost_query** — My own API usage costs (not household finances).
+
+## How to reason about financial questions
+
+- Be **direct and specific** — give numbers, not generalities. "You spent $1,247 on dining in February, up 23% from January" is better than "your dining spending has increased."
+- When answering **spending questions**, pull actual transaction data and compute totals yourself. Don't guess.
+- When answering **budget questions**, show the category breakdown with percent used. Flag categories that are over budget or trending over.
+- When answering **account/net worth questions**, group accounts by type and show a total. Be clear that balances reflect Monarch's last sync, not real-time quotes.
+- When answering **investment performance questions**, state what the data shows (current balance, account type) and what it cannot show (unrealized gains vs. cost basis, benchmark comparisons). Monarch shows balances, not performance attribution.
+- For **trend questions** (month-over-month, quarter-over-quarter), pull data for both periods and compute the comparison yourself.
+
+## Tax and equity reasoning
+
+The household files as **Married Filing Jointly** in California.
+- Federal marginal rate: **32%** (2024 bracket: $383,901–$487,450)
+- California state marginal rate: **9.3%** (2024 bracket: $137,604–$174,654)
+- Combined effective marginal rate for supplemental income (RSU/ESPP): approximately **41.3%** (federal + state), plus **1.45%** Medicare
+
+For RSU/ESPP withholding questions:
+- Supplemental income federal withholding is typically **22%** flat (or 37% above $1M)
+- California supplemental withholding is **10.23%**
+- Total typical withholding: ~**32.23%** — but the household's actual marginal rate is higher (~41.3%), so additional tax will likely be owed. Advise setting aside the difference.
+- For large grants, walk through: shares x price = gross income, minus withholding = net proceeds, minus estimated additional tax owed = true after-tax value.
+
+When tax questions go beyond what you can compute from marginal rates and standard rules (e.g., AMT implications, estate planning, wash sale rules), recommend discussing with Peter (the household's Goldman Sachs advisor).

--- a/specs/finances/FINANCES-CAPABILITY.verify.md
+++ b/specs/finances/FINANCES-CAPABILITY.verify.md
@@ -1,0 +1,45 @@
+# Finances Phase 1 — Verification Checklist
+
+## Local Verification
+
+### Tool loading
+- [ ] `npm test` passes (all non-db-schema tests)
+- [ ] 29 tools load (confirm via test output or `getToolDefinitions().length`)
+
+### finance_accounts
+- [ ] Returns grouped accounts with balances when called with no filters
+- [ ] `type` filter (e.g., `"investment"`) returns only matching accounts
+- [ ] `name` filter (e.g., `"529"`) returns only matching accounts
+- [ ] Returns `totalNetWorth` sum across all accounts
+- [ ] Returns `{ error: "..." }` when user lacks `financial` permission
+
+### finance_budget_summary
+- [ ] Returns budget vs. actual for current month when called with no args
+- [ ] `month`/`year` params return data for the specified period
+- [ ] Categories sorted by `percentUsed` descending (over-budget first)
+- [ ] Includes income and expense totals
+- [ ] Returns `{ error: "..." }` when user lacks `financial` permission
+
+### Permissions
+- [ ] `permissions.js` maps both new tools to `['financial']`
+- [ ] Only Lee has `financial` permission in `household.json`
+- [ ] Non-financial users get permission denied for both tools
+
+### Prompt / capability loading
+- [ ] Finance capability prompt loads when message matches trigger regex
+- [ ] Trigger regex matches: money, spend, budget, account, balance, net worth, 529, invest, RSU, ESPP, tax, etc.
+- [ ] Prompt includes tax context (MFJ, 32% federal, 9.3% CA)
+- [ ] Prompt includes all 5 finance tool descriptions
+
+## Regression Checks
+- [ ] Existing finance tools (`finance_transactions`, `finance_paybacks`, `cost_query`) still work
+- [ ] No other capability prompts affected
+- [ ] No changes to broker, router, or other non-finance code paths
+
+## Server Confirmation (after deploy)
+- [ ] `journalctl -u iji.service --no-pager -n 30` — no startup errors
+- [ ] Monarch auth succeeds (session token cached)
+- [ ] Send Signal DM: "What are our account balances?" → returns real Monarch data
+- [ ] Send Signal DM: "How's the budget this month?" → returns real budget data
+- [ ] Send Signal DM: "What's our net worth?" → returns account totals
+- [ ] Verify non-admin user gets permission denied for finance questions

--- a/src/brain/prompt.js
+++ b/src/brain/prompt.js
@@ -29,7 +29,7 @@ const CAPABILITY_TRIGGERS = {
   calendar: /\b(calendar|schedule|event|meeting|appointment|free|busy|available|book|when)\b/i,
   knowledge: /\b(remember|forgot|know|told you|last time|dinner|plan|logistics)\b/i,
   weather: /\b(weather|rain|cold|hot|umbrella|jacket|forecast|outside)\b/i,
-  finance: /\b(money|spend|cost|transaction|budget|pay|expense|financial)\b/i,
+  finance: /\b(money|spend|cost|transaction|budget|pay|expense|financial|account|balance|net worth|529|invest|cash|burn rate|withhold|equity|RSU|ESPP|tax)\b/i,
   email: /\b(email|inbox|gmail|message from|mail)\b/i,
   sms: /\b(text|sms|txt)\b/i,
   messaging: /\b(tell |send |message |text |relay |let .* know)\b/i,

--- a/src/tools/finance-accounts.js
+++ b/src/tools/finance-accounts.js
@@ -1,0 +1,107 @@
+import * as monarch from '../utils/monarch.js';
+import log from '../utils/logger.js';
+
+export const definition = {
+  name: 'finance_accounts',
+  description:
+    'Get a snapshot of all household financial accounts from Monarch Money — checking, savings, investment, credit cards, loans, 529s. Shows current balance, account type, and institution. Use this to answer questions about cash on hand, net worth, or specific account balances.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      type: {
+        type: 'string',
+        description:
+          'Optional filter by account type: "depository" (checking/savings), "investment" (brokerage, 529, retirement), "credit" (credit cards), "loan" (mortgages, loans). Leave empty for all accounts.',
+      },
+      name: {
+        type: 'string',
+        description:
+          'Optional filter by account name (partial match, case-insensitive). E.g. "529", "Chase", "Fidelity".',
+      },
+    },
+  },
+};
+
+function formatBalance(amount) {
+  if (amount == null) return '--';
+  const abs = Math.abs(amount).toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  return amount < 0 ? `-$${abs}` : `$${abs}`;
+}
+
+function classifyType(account) {
+  const typeName = account.type?.name?.toLowerCase() || '';
+  if (typeName.includes('depository') || typeName.includes('checking') || typeName.includes('savings')) return 'depository';
+  if (typeName.includes('investment') || typeName.includes('brokerage') || typeName.includes('retirement')) return 'investment';
+  if (typeName.includes('credit')) return 'credit';
+  if (typeName.includes('loan') || typeName.includes('mortgage')) return 'loan';
+  return typeName || 'other';
+}
+
+export async function execute(input, _envelope) {
+  const typeFilter = (input?.type || '').trim().toLowerCase();
+  const nameFilter = (input?.name || '').trim().toLowerCase();
+
+  let accounts;
+  try {
+    accounts = await monarch.getAccounts();
+  } catch (e) {
+    log.error('Finance accounts failed', { error: e.message });
+    return {
+      error: 'Financial data is temporarily unavailable. Lee has been notified.',
+    };
+  }
+
+  // TODO: existing auth bug — monarch.getAccounts() may return 'UNAUTHORIZED'
+  // string on persistent session failures. Not fixing in this task.
+  if (accounts === 'UNAUTHORIZED' || !Array.isArray(accounts)) {
+    return {
+      error: 'Financial data is temporarily unavailable. Lee has been notified.',
+    };
+  }
+
+  let results = accounts.map((a) => ({
+    name: a.displayName || 'Unknown',
+    type: classifyType(a),
+    typeDisplay: a.type?.display || a.type?.name || '--',
+    subtype: a.subtype?.display || a.subtype?.name || null,
+    balance: a.currentBalance ?? a.displayBalance ?? null,
+    balanceFormatted: formatBalance(a.currentBalance ?? a.displayBalance),
+  }));
+
+  if (typeFilter) {
+    results = results.filter((a) => a.type === typeFilter);
+  }
+  if (nameFilter) {
+    results = results.filter((a) => a.name.toLowerCase().includes(nameFilter));
+  }
+
+  if (results.length === 0) {
+    const filterDesc = [typeFilter, nameFilter].filter(Boolean).join(', ');
+    return {
+      message: filterDesc
+        ? `No accounts found matching: ${filterDesc}`
+        : 'No accounts found in Monarch.',
+      accounts: [],
+    };
+  }
+
+  // Group by type for summary
+  const byType = {};
+  let totalNet = 0;
+  for (const a of results) {
+    if (!byType[a.typeDisplay]) byType[a.typeDisplay] = [];
+    byType[a.typeDisplay].push(a);
+    if (a.balance != null) totalNet += a.balance;
+  }
+
+  return {
+    accounts: results,
+    totalNetWorth: formatBalance(totalNet),
+    totalNetWorthRaw: totalNet,
+    accountCount: results.length,
+    message: `${results.length} account(s) found. Net total: ${formatBalance(totalNet)}.`,
+  };
+}

--- a/src/tools/finance-budget-summary.js
+++ b/src/tools/finance-budget-summary.js
@@ -1,0 +1,152 @@
+import * as monarch from '../utils/monarch.js';
+import log from '../utils/logger.js';
+
+export const definition = {
+  name: 'finance_budget_summary',
+  description:
+    'Get the household budget vs. actual spending for a given month from Monarch Money. Shows each budget category with planned amount, actual spend, remaining, and percent used. Use this to answer questions about budget health, overspending, and where to trim.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      month: {
+        type: 'number',
+        description: 'Month number (1-12). Default: current month.',
+      },
+      year: {
+        type: 'number',
+        description: 'Four-digit year. Default: current year.',
+      },
+    },
+  },
+};
+
+function formatDollars(amount) {
+  if (amount == null) return '--';
+  const abs = Math.abs(amount).toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  return amount < 0 ? `-$${abs}` : `$${abs}`;
+}
+
+/**
+ * Build a category lookup from categoryGroups returned by the budget query.
+ * Returns Map<categoryId, { name, groupName, groupType }>
+ */
+function buildCategoryLookup(categoryGroups) {
+  const lookup = new Map();
+  if (!Array.isArray(categoryGroups)) return lookup;
+  for (const group of categoryGroups) {
+    for (const cat of group.categories || []) {
+      lookup.set(cat.id, {
+        name: cat.name,
+        groupName: group.name,
+        groupType: group.type,
+      });
+    }
+  }
+  return lookup;
+}
+
+export async function execute(input, _envelope) {
+  const now = new Date();
+  const month = Math.max(1, Math.min(12, Number(input?.month) || (now.getMonth() + 1)));
+  const year = Number(input?.year) || now.getFullYear();
+
+  const mm = String(month).padStart(2, '0');
+  const lastDay = new Date(year, month, 0).getDate();
+  const startDate = `${year}-${mm}-01`;
+  const endDate = `${year}-${mm}-${lastDay}`;
+
+  let data;
+  try {
+    data = await monarch.getBudgets({ startDate, endDate });
+  } catch (e) {
+    log.error('Finance budget summary failed', { error: e.message });
+    return {
+      error: 'Financial data is temporarily unavailable. Lee has been notified.',
+    };
+  }
+
+  // TODO: existing auth bug — monarch.getBudgets() may return 'UNAUTHORIZED'
+  // string on persistent session failures. Not fixing in this task.
+  if (data === 'UNAUTHORIZED' || !data) {
+    return {
+      error: 'Financial data is temporarily unavailable. Lee has been notified.',
+    };
+  }
+
+  const budgetData = data.budgetData;
+  const categoryGroups = data.categoryGroups;
+
+  if (!budgetData) {
+    return {
+      message: 'No budget data available for this month. Budgets may not be configured in Monarch.',
+      categories: [],
+    };
+  }
+
+  const catLookup = buildCategoryLookup(categoryGroups);
+  const categories = [];
+
+  for (const entry of budgetData.monthlyAmountsByCategory || []) {
+    const catId = entry.category?.id;
+    const catInfo = catLookup.get(catId) || { name: catId || 'Unknown', groupName: '--' };
+    const amounts = (entry.monthlyAmounts || []).find(
+      (a) => a.month && a.month.startsWith(`${year}-${mm}`)
+    );
+
+    if (!amounts) continue;
+
+    const planned = amounts.plannedCashFlowAmount ?? 0;
+    const actual = amounts.actualAmount ?? 0;
+    const remaining = amounts.remainingAmount ?? (planned - Math.abs(actual));
+
+    // Skip categories with no budget and no spend
+    if (planned === 0 && actual === 0) continue;
+
+    const percentUsed = planned !== 0 ? Math.round((Math.abs(actual) / Math.abs(planned)) * 100) : null;
+
+    categories.push({
+      category: catInfo.name,
+      group: catInfo.groupName,
+      budgeted: formatDollars(planned),
+      spent: formatDollars(actual),
+      remaining: formatDollars(remaining),
+      percentUsed: percentUsed != null ? `${percentUsed}%` : '--',
+      budgetedRaw: planned,
+      spentRaw: actual,
+      remainingRaw: remaining,
+    });
+  }
+
+  // Sort: over-budget first (highest percentUsed), then by spend
+  categories.sort((a, b) => {
+    const aPct = parseInt(a.percentUsed) || 0;
+    const bPct = parseInt(b.percentUsed) || 0;
+    return bPct - aPct;
+  });
+
+  // Totals from the API
+  const totals = (budgetData.totalsByMonth || []).find(
+    (t) => t.month && t.month.startsWith(`${year}-${mm}`)
+  );
+  const totalExpenses = totals?.totalExpenses || {};
+  const totalIncome = totals?.totalIncome || {};
+
+  const monthName = new Date(year, month - 1).toLocaleString('en-US', { month: 'long' });
+
+  return {
+    month: `${monthName} ${year}`,
+    categories,
+    totals: {
+      incomePlanned: formatDollars(totalIncome.plannedAmount),
+      incomeActual: formatDollars(totalIncome.actualAmount),
+      expensesPlanned: formatDollars(totalExpenses.plannedAmount),
+      expensesActual: formatDollars(totalExpenses.actualAmount),
+      expensesRemaining: formatDollars(totalExpenses.remainingAmount),
+    },
+    categoryCount: categories.length,
+    message: `Budget summary for ${monthName} ${year}: ${categories.length} active categories.`,
+  };
+}

--- a/src/tools/index.js
+++ b/src/tools/index.js
@@ -10,6 +10,8 @@ import * as messageSend from './message-send.js';
 import * as weatherQuery from './weather-query.js';
 import * as financeTransactions from './finance-transactions.js';
 import * as financePaybacks from './finance-paybacks.js';
+import * as financeAccounts from './finance-accounts.js';
+import * as financeBudgetSummary from './finance-budget-summary.js';
 import * as costQuery from './cost-query.js';
 import * as emailSearch from './email-search.js';
 import * as emailRead from './email-read.js';
@@ -41,6 +43,8 @@ const tools = {
   weather_query: weatherQuery,
   finance_transactions: financeTransactions,
   finance_paybacks: financePaybacks,
+  finance_accounts: financeAccounts,
+  finance_budget_summary: financeBudgetSummary,
   cost_query: costQuery,
   email_search: emailSearch,
   email_read: emailRead,

--- a/src/utils/monarch.js
+++ b/src/utils/monarch.js
@@ -247,6 +247,63 @@ const GET_CATEGORIES_QUERY = `
   }
 `;
 
+const GET_BUDGET_QUERY = `
+  query GetJointPlanningData($startDate: Date!, $endDate: Date!, $useV2Goals: Boolean!) {
+    budgetData(startMonth: $startDate, endMonth: $endDate) {
+      monthlyAmountsByCategory {
+        category {
+          id
+          __typename
+        }
+        monthlyAmounts {
+          month
+          plannedCashFlowAmount
+          actualAmount
+          remainingAmount
+          __typename
+        }
+        __typename
+      }
+      totalsByMonth {
+        month
+        totalIncome {
+          plannedAmount
+          actualAmount
+          remainingAmount
+          __typename
+        }
+        totalExpenses {
+          plannedAmount
+          actualAmount
+          remainingAmount
+          __typename
+        }
+        __typename
+      }
+      __typename
+    }
+    categoryGroups {
+      id
+      name
+      order
+      type
+      categories {
+        id
+        name
+        order
+        __typename
+      }
+      __typename
+    }
+    goalsV2 @include(if: $useV2Goals) {
+      id
+      name
+      __typename
+    }
+    budgetSystem
+  }
+`;
+
 const GET_TRANSACTIONS_QUERY = `
   query GetTransactionsList($offset: Int, $limit: Int, $filters: TransactionFilterInput, $orderBy: TransactionOrdering) {
     allTransactions(filters: $filters) {
@@ -290,6 +347,32 @@ export async function getCategories() {
     const data = await graphql('GetCategories', GET_CATEGORIES_QUERY, {}, token);
     if (data === 'UNAUTHORIZED') return data;
     return data?.categories ?? [];
+  });
+}
+
+/**
+ * Get budget data for a given month range.
+ * @param {Object} [opts]
+ * @param {string} [opts.startDate] - YYYY-MM-DD (default: first of current month)
+ * @param {string} [opts.endDate] - YYYY-MM-DD (default: last of current month)
+ */
+export async function getBudgets(opts = {}) {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = now.getMonth();
+  const startDate = opts.startDate || `${y}-${String(m + 1).padStart(2, '0')}-01`;
+  const lastDay = new Date(y, m + 1, 0).getDate();
+  const endDate = opts.endDate || `${y}-${String(m + 1).padStart(2, '0')}-${lastDay}`;
+
+  return withAuth(async (token) => {
+    const data = await graphql(
+      'GetJointPlanningData',
+      GET_BUDGET_QUERY,
+      { startDate, endDate, useV2Goals: false },
+      token
+    );
+    if (data === 'UNAUTHORIZED') return data;
+    return data;
   });
 }
 

--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -21,6 +21,8 @@ const TOOL_PERMISSIONS = {
   message_send: ['message_send'],
   finance_transactions: ['financial'],
   finance_paybacks: ['financial'],
+  finance_accounts: ['financial'],
+  finance_budget_summary: ['financial'],
   cost_query: ['financial'],
   email_search: ['email_own', 'email_all'],
   email_read: ['email_own', 'email_all'],


### PR DESCRIPTION
## Summary
- **finance_accounts** tool: snapshot of all household accounts from Monarch Money with type/name filters, net worth calculation
- **finance_budget_summary** tool: budget vs. actual spending by category for any month, sorted by percent used
- **getBudgets()** added to `monarch.js` using `GetJointPlanningData` GraphQL query
- Finance capability prompt with tax/equity reasoning context (MFJ, CA, RSU/ESPP withholding guidance)
- Both tools gated behind `financial` permission (Lee only)
- Phase 1 is additive only — existing auth/state bugs noted as TODOs, not fixed

## Files changed
- `src/utils/monarch.js` — added `getBudgets()` + GraphQL query
- `src/tools/finance-accounts.js` — new tool
- `src/tools/finance-budget-summary.js` — new tool
- `src/tools/index.js` — register both tools
- `src/utils/permissions.js` — add permission mappings
- `config/prompts/capabilities/finance.md` — capability prompt
- `src/brain/prompt.js` — updated trigger regex
- `BACKLOG.md` — updated scorecard
- `specs/finances/FINANCES-CAPABILITY.verify.md` — verification checklist

## Test plan
- [ ] `npm test` passes (96/96, 5 pre-existing db-schema failures unrelated)
- [ ] 29 tools load correctly
- [ ] Permission gating works (only `financial` permission holders can use)
- [ ] Server deploy: test with real Monarch data via Signal DM
- [ ] Verify budget and account data returns correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)