### PR TITLE
Weather Updates in Signal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "household-agent",
       "version": "0.1.0",
+      "license": "ISC",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
         "@slack/socket-mode": "^2.0.6",

--- a/src/utils/daily-ops.js
+++ b/src/utils/daily-ops.js
@@ -10,10 +10,6 @@ const DAILY_OPS_ENABLED = process.env.DAILY_OPS_ENABLED !== 'false';
 const WAKING_HOUR_START = 7;  // 7am Pacific
 const WAKING_HOUR_END = 22;   // 10pm Pacific
 
-const NWS_USER_AGENT = 'Iji Household Agent, contact@email.com';
-const DEFAULT_LAT = 37.8716;
-const DEFAULT_LNG = -122.2727;
-
 // In-memory dedup: sent nudge keys (personId:type:id:dateKey)
 const sentToday = new Set();
 
@@ -98,51 +94,6 @@ export function getOverdueTasks(personId) {
   }
 }
 
-async function checkRainStartingSoon() {
-  try {
-    const pointsUrl = `https://api.weather.gov/points/${DEFAULT_LAT},${DEFAULT_LNG}`;
-    const pointsRes = await fetch(pointsUrl, {
-      headers: { 'User-Agent': NWS_USER_AGENT },
-    });
-    if (!pointsRes.ok) return null;
-    const pointsData = await pointsRes.json();
-    const hourlyUrl = pointsData?.properties?.forecastHourly;
-    if (!hourlyUrl) return null;
-
-    const hourlyRes = await fetch(hourlyUrl, {
-      headers: { 'User-Agent': NWS_USER_AGENT },
-    });
-    if (!hourlyRes.ok) return null;
-    const hourlyData = await hourlyRes.json();
-    const periods = (hourlyData?.properties?.periods || []).slice(0, 4);
-
-    for (const period of periods) {
-      const precip = period?.probabilityOfPrecipitation?.value;
-      if (precip != null && precip >= 50) {
-        const startTime = period.startTime ? new Date(period.startTime) : null;
-        const timeStr = startTime
-          ? startTime.toLocaleTimeString('en-US', {
-              hour: 'numeric',
-              minute: '2-digit',
-              hour12: true,
-              timeZone: 'America/Los_Angeles',
-            })
-          : 'soon';
-        return {
-          probability: precip,
-          shortForecast: period.shortForecast || 'Rain',
-          time: timeStr,
-          startTime: period.startTime,
-        };
-      }
-    }
-    return null;
-  } catch (err) {
-    log.warn('Daily ops: weather check failed', { error: err.message });
-    return null;
-  }
-}
-
 async function collectActionableItems(personId, dateKey) {
   const items = [];
 
@@ -168,15 +119,6 @@ async function collectActionableItems(personId, dateKey) {
     const key = `${personId}:task:${task.id}:${dateKey}`;
     if (!sentToday.has(key)) {
       items.push({ type: 'task', key, title: task.title, due_at: task.due_at });
-    }
-  }
-
-  // Rain starting in the next 4 hours (dedup once per day per person)
-  const rainKey = `${personId}:weather-rain:${dateKey}`;
-  if (!sentToday.has(rainKey)) {
-    const rain = await checkRainStartingSoon();
-    if (rain) {
-      items.push({ type: 'weather', key: rainKey, ...rain });
     }
   }
 
@@ -215,7 +157,6 @@ export async function runDailyOpsCheck() {
       const itemDescriptions = items.map((i) => {
         if (i.type === 'calendar') return `- Upcoming event in next 2 hours: "${i.summary}" at ${i.start}${i.location ? ` (${i.location})` : ''}`;
         if (i.type === 'task') return `- Overdue task: "${i.title}"`;
-        if (i.type === 'weather') return `- Rain starting around ${i.time} (${i.probability}% chance, ${i.shortForecast})`;
         return `- ${i.type}: ${JSON.stringify(i)}`;
       }).join('\n');
 
@@ -229,7 +170,7 @@ export async function runDailyOpsCheck() {
 The following items may need their attention right now:
 ${itemDescriptions}
 
-Check any relevant details needed for context (e.g. if an outdoor event or kid pickup is involved, check weather; if a task is overdue, give a brief note). Send a concise Signal message — 1-3 sentences max. Focus only on what's immediately actionable. Write like a Chief of Staff giving a quick heads-up.
+Check any relevant details needed for context (e.g. if a task is overdue, check for any related context; if an event is coming up, note key details). Send a concise Signal message — 1-3 sentences max. Focus only on what's immediately actionable. Write like a Chief of Staff giving a quick heads-up.
 
 If after reviewing context nothing is truly urgent or actionable right now, respond with exactly: SKIP`,
         source_channel: 'signal',

--- a/src/utils/morning-briefing.js
+++ b/src/utils/morning-briefing.js
@@ -99,7 +99,7 @@ async function runMorningBriefingCycle() {
           .get();
         const count = Number(row?.count || 0);
         if (count > 0) {
-          featureRequestsLine = `\n6. 📋 ${count} new feature request${count > 1 ? 's' : ''} to review.`;
+          featureRequestsLine = `\n5. 📋 ${count} new feature request${count > 1 ? 's' : ''} to review.`;
         }
       } catch (err) {
         log.warn('Morning briefing feature request count failed', {
@@ -118,10 +118,9 @@ async function runMorningBriefingCycle() {
 
 Check the following and include anything noteworthy:
 1. Their calendar for today — events, times, locations. Flag conflicts with other household members if you spot them.
-2. Current weather and today's forecast — mention only if it affects plans or is notable.
-3. Pending reminders due today or overdue.
-4. Anything stored in household knowledge in the last 24 hours that's relevant to them.
-5. Any tasks assigned to them that are overdue or due today.
+2. Pending reminders due today or overdue.
+3. Anything stored in household knowledge in the last 24 hours that's relevant to them.
+4. Any tasks assigned to them that are overdue or due today.
 ${featureRequestsLine}
 
 Keep it concise — this is a Signal message, not an email. Lead with the most important item. Skip sections with nothing noteworthy (don't say "no reminders" — just omit). Write like a Chief of Staff giving a 30-second verbal briefing.`,

--- a/test/daily-ops.test.js
+++ b/test/daily-ops.test.js
@@ -320,48 +320,50 @@ describe('runDailyOpsCheck: SKIP response not sent', () => {
   });
 });
 
-describe('runDailyOpsCheck: weather nudge', () => {
-  it('includes weather info when rain is starting soon', async () => {
+describe('runDailyOpsCheck: no weather alerts', () => {
+  it('does not call fetch (NWS API) during daily ops check', async () => {
+    const { getCalendarClient, getCalendarIds } = await import('../src/utils/google-calendar.js');
+
+    getCalendarClient.mockResolvedValue(null);
+    getCalendarIds.mockReturnValue({});
+
+    const fetchSpy = vi.fn();
+    global.fetch = fetchSpy;
+
+    await runDailyOpsCheck();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    delete global.fetch;
+  });
+
+  it('does not include rain/weather info in nudge even when high precipitation', async () => {
     const { getCalendarClient, getCalendarIds } = await import('../src/utils/google-calendar.js');
     const { think } = await import('../src/brain/index.js');
 
     getCalendarClient.mockResolvedValue(null);
     getCalendarIds.mockReturnValue({});
 
-    // Mock NWS points + hourly forecast with rain
-    const pointsResponse = {
-      properties: {
-        forecastHourly: 'https://api.weather.gov/gridpoints/MTR/92,88/forecast/hourly',
-      },
-    };
-    const hourlyResponse = {
-      properties: {
-        periods: [
-          {
-            startTime: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
-            shortForecast: 'Light Rain',
-            probabilityOfPrecipitation: { value: 70 },
-            temperature: 58,
-          },
-        ],
-      },
-    };
+    insertOverdueTask('alice', 'Water the plants');
 
-    let callCount = 0;
-    global.fetch = vi.fn().mockImplementation(() => {
-      callCount++;
-      const data = callCount === 1 ? pointsResponse : hourlyResponse;
-      return Promise.resolve({
-        ok: true,
-        json: async () => data,
-      });
+    // Make NWS respond with heavy rain — should never be consulted
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        properties: {
+          forecastHourly: 'https://api.weather.gov/gridpoints/MTR/92,88/forecast/hourly',
+          periods: [{ probabilityOfPrecipitation: { value: 90 }, shortForecast: 'Heavy Rain' }],
+        },
+      }),
     });
 
     await runDailyOpsCheck();
 
-    expect(think).toHaveBeenCalled();
-    const callArgs = think.mock.calls[0][0];
-    expect(callArgs.message).toMatch(/Rain/i);
+    if (think.mock.calls.length > 0) {
+      const callArgs = think.mock.calls[0][0];
+      expect(callArgs.message).not.toMatch(/rain/i);
+      expect(callArgs.message).not.toMatch(/weather/i);
+    }
 
     delete global.fetch;
   });

--- a/test/morning-briefing.test.js
+++ b/test/morning-briefing.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/broker/signal.js', () => ({
+  sendMessage: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('../src/brain/index.js', () => ({
+  think: vi.fn().mockResolvedValue('Good morning! You have two meetings today.'),
+}));
+
+vi.mock('../src/utils/config.js', () => ({
+  getHousehold: vi.fn().mockReturnValue({
+    members: {
+      alice: {
+        display_name: 'Alice',
+        role: 'adult',
+        permissions: ['calendar_all'],
+        identifiers: { signal: '+15105550001' },
+        briefing: { enabled: true, delivery_hour: 7 },
+      },
+    },
+  }),
+}));
+
+vi.mock('../src/utils/db.js', () => ({
+  getDb: vi.fn().mockReturnValue({
+    prepare: vi.fn().mockReturnValue({
+      get: vi.fn().mockReturnValue(null),
+    }),
+  }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('morning briefing prompt', () => {
+  it('does not include weather in the briefing prompt', async () => {
+    const { think } = await import('../src/brain/index.js');
+    const { startMorningBriefing } = await import('../src/utils/morning-briefing.js');
+
+    startMorningBriefing();
+
+    // Give async cycle time to run
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    if (think.mock.calls.length > 0) {
+      const callArgs = think.mock.calls[0][0];
+      expect(callArgs.message).not.toMatch(/weather/i);
+      expect(callArgs.message).not.toMatch(/forecast/i);
+    } else {
+      // If think wasn't called, skip — briefing may not have triggered at this hour
+      expect(true).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Bug fix: Weather Updates in Signal\n\nAutomated PR created by OpenClaw Watcher.\n\nCloses #97\n\n---\n\n<details><summary>Spec/Description</summary>\n\n### Summary\n\nIji's weather updates in Signal are reporting incorrect temperatures (20°F+ off) and firing too frequently via rain alerts every 30 minutes. User does not want any weather updates from Iji.\n\n### Steps to Reproduce\n\nIji posts weather/rain alerts via Signal multiple times daily with incorrect temperature data.\n\n### Expected Behavior\n\nIji does not send any weather-related messages — no rain alerts, no weather in morning briefings, nothing.\n\n### Actual Behavior\n\nIji sends frequent rain alerts (daily-ops scheduler, every 30 min) and includes weather context in morning briefings, with incorrect temperature numbers.\n\n### Severity\n\nCritical — system down or data loss\n\n### Acceptance Criteria\n\n- [ ] Rain alert logic removed from  —  no longer called\n- [ ] Weather context removed from morning briefing prompt in \n- [ ] No weather-related messages are sent via Signal under any automated flow\n- [ ] The  tool can remain available for manual/on-demand use — just remove all automated triggers\n- [ ] Tests pass\n\n### Root Cause\n\n1. Rain alerts fire every 30 min via daily-ops scheduler when precipitation ≥ 50%\n2. Temperature data from NWS observation stations may be pulling from wrong station or has conversion issues\n3. User does not want any automated weather updates regardless of accuracy\n\n</details>