### PR TITLE
feat: monarch → google sheets asset sync (monthly)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,9 @@ MONARCH_TOTP_SECRET=
 # MONARCH_PAYBACKS_STATE_FILE=
 # Override default session file location (default: data/monarch-session.json)
 # MONARCH_SESSION_FILE=
+# Google Sheets spreadsheet ID for the monthly asset sync job (src/jobs/sync-assets.js).
+# Lee's OAuth token must be authorized for the spreadsheets scope.
+FINANCE_SPREADSHEET_ID=
 
 # Education Advisor (Supabase — powers education_profile, education_documents, education_goals, education_team, education_upload)
 SUPABASE_URL=https://your-project.supabase.co

--- a/specs/finances/ASSET-SYNC.md
+++ b/specs/finances/ASSET-SYNC.md
@@ -1,0 +1,107 @@
+# Spec: Monarch → Google Sheets Asset Sync
+
+**ID:** FINANCES-ASSET-SYNC
+**Author:** Claude (Engineer)
+**Status:** Approved
+**GitHub Issue:** —
+
+---
+
+## Problem
+
+The family's finance model lives in a Google Sheet ("Finance Model"). The "Current Portfolio Value" input on the Inputs tab references `Assets!B9`, but nobody is keeping the Assets tab up to date — it has to be refreshed manually from Monarch each month, which means in practice it drifts.
+
+## Context
+
+Iji already has a working Monarch Money integration (`src/utils/monarch.js`) with `getAccounts()` returning accounts + balances + `type { name }`. It also has Google OAuth per-user token infrastructure (`src/utils/google-oauth.js`) currently used for Gmail and Drive. No Sheets API wrapper exists yet.
+
+Read ARCHITECTURE.md for the four-flow design — this feature is a scheduled job, not a tool. It runs in the background and does not go through the brain/router.
+
+## Goal
+
+Every month, pull asset balances from Monarch, sum them by type, and write the totals into the Assets tab of the finance spreadsheet so the model always reflects current reality.
+
+## Design Decision
+
+**OAuth, not service account.** Calendar uses a service account; Gmail/Drive use per-user OAuth. Sheets could go either way, but the finance model is owned by Lee personally and we already have Lee's OAuth refresh token. Using OAuth (Lee's identity) avoids sharing the sheet with a new service account principal and reuses existing infrastructure. Cost: re-auth is required to grant the new `spreadsheets` scope.
+
+**`setInterval` scheduler, not `node-cron`.** The project has no cron dependency and all other schedulers (`morning-briefing.js`, `daily-ops.js`, `reminder-scheduler.js`) use a 1-minute `setInterval` that checks Pacific time and dedupes by date key. Adding `node-cron` for one monthly job is unjustified dependency creep. We follow the house pattern.
+
+**Errors route to Signal, not just logs.** Asset sync runs headless — if it silently fails for six months, the finance model becomes wrong and Lee would only notice when making a decision based on stale data. Separate `MonarchAuthError` and `SheetsWriteError` classes produce distinct Signal messages so Lee knows exactly what to fix.
+
+**Startup run + monthly schedule.** Running only on the 1st of the month means bugs aren't visible until 30 days after deploy. A 30s-delayed startup run exercises the full path immediately on every deploy without materially changing when the monthly write happens.
+
+## What to Build
+
+### 1. Google Sheets utility
+
+**File:** `src/utils/sheets.js` (Create)
+
+Lightweight wrapper around `google.sheets({version: 'v4'})`. Reuses `getClient(personId, scopes)` from `google-oauth.js`.
+
+**Exports:**
+- `writeValues(spreadsheetId, range, values, personId='lee')` — calls `spreadsheets.values.update` with `valueInputOption: 'USER_ENTERED'`. Caches the sheets client per-person; invalidates the cache on any write error so stale/revoked auth recovers on next call.
+
+### 2. Sheets OAuth scope
+
+**File:** `src/utils/google-oauth.js` (Modify)
+
+Add `SHEETS_SCOPES = ['https://www.googleapis.com/auth/spreadsheets']` and include it in `ALL_GOOGLE_SCOPES` so a re-auth grants it alongside Gmail/Drive.
+
+### 3. Asset sync job
+
+**File:** `src/jobs/sync-assets.js` (Create — establishes new `src/jobs/` directory)
+
+Pulls from Monarch, sums by `type.name`, writes to Sheets.
+
+**Cell targets (Assets tab):**
+
+| Value | Cell | Source |
+|---|---|---|
+| Total Investable | `Assets!B9` | sum of `type.name === 'investment'` |
+| Total Illiquid | `Assets!B18` | sum of `type.name === 'real_estate'` + `'other_asset'` |
+| Last Synced | `Assets!B26` | Pacific timestamp string |
+
+**Exports:**
+- `syncAssets()` — never throws. Returns `{ok, totalInvestable, totalIlliquid}` or `{ok:false, error}`. On `MonarchAuthError` → Signals Lee "Asset sync failed: Monarch authentication error." On `SheetsWriteError` → Signals Lee "Asset sync failed: Could not write to Google Sheets."
+- `startAssetSyncScheduler({startupDelayMs})` — kicks off a 30s-delayed startup run and a 1-minute `setInterval` that fires `syncAssets()` when Pacific date is day=1 and hour≥6, deduped by `YYYY-MM`.
+
+**Direct invocation:** `node src/jobs/sync-assets.js` runs the sync once and exits with code 0/1. Used for local testing and EC2 smoke tests.
+
+### 4. Scheduler registration
+
+**File:** `src/index.js` (Modify)
+
+After `startDailyOps()`, if `FINANCE_SPREADSHEET_ID` is set, import and call `startAssetSyncScheduler()`. Guard on env var presence so existing deploys without the var are unaffected.
+
+## Files to Create/Modify
+
+| File | Action | Description |
+|------|--------|-------------|
+| `src/utils/sheets.js` | Create | Google Sheets v4 writer |
+| `src/jobs/sync-assets.js` | Create | Monarch → Sheets sync + scheduler |
+| `src/utils/google-oauth.js` | Modify | Add `SHEETS_SCOPES`, include in `ALL_GOOGLE_SCOPES` |
+| `src/index.js` | Modify | Register asset sync scheduler |
+| `.env.example` | Modify | Document `FINANCE_SPREADSHEET_ID` |
+
+## Server Requirements
+
+- [ ] Env var `FINANCE_SPREADSHEET_ID=193JJvxdWw_Y9k0oBAyDmku43OEkncj0T8DX8htVWVfo` added to EC2 `.env`
+- [x] Env var added to `.env.example`
+- [x] Dependency installed (`googleapis` already in `package.json`)
+- [ ] Lee re-authorizes Google OAuth — existing token lacks the `spreadsheets` scope
+- [ ] Assets tab B9/B18/B26 positions verified against live sheet before first run
+
+## Dependencies
+
+Zero new dependencies. `googleapis` is already installed for Calendar/Gmail.
+
+## Do NOT Change
+
+- `src/utils/monarch.js` — asset sync only calls existing `getAccounts()`
+- `src/utils/google-oauth.js` aside from adding `SHEETS_SCOPES`
+- Any existing scheduler — we add a new one alongside, we don't modify
+
+## Commit Message
+
+`feat: monarch → google sheets asset sync (monthly)`

--- a/specs/finances/ASSET-SYNC.verify.md
+++ b/specs/finances/ASSET-SYNC.verify.md
@@ -1,0 +1,75 @@
+# Verification: Monarch → Google Sheets Asset Sync
+
+**Spec:** `specs/finances/ASSET-SYNC.md`
+**Date:** 2026-04-04
+**Verified by:** Claude (Engineer) + Lee (Product)
+
+---
+
+## Pre-Deploy Checks (Engineer/Dev)
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Code compiles / no syntax errors | [x] | `node --check` passes on all 4 files |
+| Only spec'd files were modified | [x] | sheets.js, sync-assets.js, google-oauth.js, index.js, .env.example + spec files |
+| `npm test` passes (if tests exist) | [ ] | Run before merge |
+| Env vars added to `.env.example` | [x] | `FINANCE_SPREADSHEET_ID=` in Monarch section |
+| No secrets in committed code | [x] | Spreadsheet ID is public to family — env var is for config cleanliness, not secrecy |
+
+## Server Configuration (Engineer → Product)
+
+| Requirement | Applied? | Notes |
+|-------------|----------|-------|
+| `FINANCE_SPREADSHEET_ID` in EC2 `.env` | [ ] | Value: `193JJvxdWw_Y9k0oBAyDmku43OEkncj0T8DX8htVWVfo` |
+| Lee re-authorizes Google OAuth w/ `spreadsheets` scope | [ ] | Existing token lacks this scope |
+| Assets tab B9/B18/B26 positions match spec | [ ] | Open sheet, confirm rows before first run |
+
+## Functional Tests (Engineer via direct invocation)
+
+| ID | Scenario | Command | Expected Result | Pass? |
+|----|----------|---------|-----------------|-------|
+| T-01 | Happy path on EC2 | `ssh ec2 "cd household-agent && node src/jobs/sync-assets.js"` | Exit 0, logs "Asset sync: complete" | [ ] |
+| T-02 | B9 populated | Open sheet, check Assets!B9 | Non-zero number matching sum of Monarch investment accounts | [ ] |
+| T-03 | B18 populated | Open sheet, check Assets!B18 | Non-zero number matching sum of real_estate + other_asset | [ ] |
+| T-04 | B26 populated | Open sheet, check Assets!B26 | Recent Pacific timestamp | [ ] |
+| T-05 | Inputs tab flows through | Open sheet, check Inputs!Current Portfolio Value | Reflects new B9 value | [ ] |
+| T-06 | Monarch auth failure alert | Delete `data/monarch-session.json` + set bad MONARCH_PASSWORD, run job | Signal DM to Lee: "Asset sync failed: Monarch authentication error." | [ ] |
+| T-07 | Sheets auth failure alert | Temporarily clobber Lee's entry in `data/oauth-tokens.json`, run job | Signal DM to Lee: "Asset sync failed: Could not write to Google Sheets." | [ ] |
+| T-08 | Startup auto-run | Restart iji.service, wait 60s, check logs | "Asset sync: startup run" followed by "Asset sync: complete" | [ ] |
+
+## Regression Checks
+
+| Area | Check | Pass? |
+|------|-------|-------|
+| Startup | `journalctl -u iji.service -n 50` shows no new errors | [ ] |
+| Gmail tool | Send a test email through Iji — still works (OAuth reshare didn't break Gmail scope) | [ ] |
+| Calendar tool | Ask Iji for today's events — still works | [ ] |
+| Monarch tools | Ask Iji "what's my current checking balance" — still works | [ ] |
+| Signal broker | Normal DM to Iji still replies | [ ] |
+
+## Log Verification (Engineer via EC2)
+
+```bash
+ssh -i ~/.ssh/the-pem-key.pem ubuntu@34.208.73.189
+journalctl -u iji.service --no-pager -n 100 | grep -i "asset sync"
+```
+
+| Check | Status |
+|-------|--------|
+| "Asset sync: startup run" appears within 1 min of restart | [ ] |
+| "Asset sync: computed totals" logged with plausible numbers | [ ] |
+| "Sheets write ok" logged 3 times (B9, B18, B26) | [ ] |
+| "Asset sync: complete" logged | [ ] |
+| No "UNAUTHORIZED" or 401/403 errors | [ ] |
+
+## Result
+
+- [ ] **PASS** — All checks green. Feature is complete.
+- [ ] **FAIL** — Issues found. See notes. → Bugfix spec needed.
+
+## Rollout
+
+This is a headless background job — no user-facing rollout. Only Lee interacts with it (indirectly, via the finance spreadsheet).
+
+- [ ] Lee has confirmed the finance model still calculates correctly after first sync
+- [ ] Monthly run on the 1st verified by Lee at least once before considering the feature fully adopted

--- a/src/index.js
+++ b/src/index.js
@@ -60,5 +60,12 @@ startKnowledgeExpiryScheduler();
 const { startDailyOps } = await import('./utils/daily-ops.js');
 startDailyOps();
 
+// Monthly Monarch → Google Sheets asset sync (1st of month, 6am Pacific).
+// Also runs once ~30s after startup so the sheet is populated on first deploy.
+if (process.env.FINANCE_SPREADSHEET_ID?.trim()) {
+  const { startAssetSyncScheduler } = await import('./jobs/sync-assets.js');
+  startAssetSyncScheduler();
+}
+
 const { startHealthServer } = await import('./health.js');
 startHealthServer();

--- a/src/jobs/sync-assets.js
+++ b/src/jobs/sync-assets.js
@@ -1,0 +1,222 @@
+/**
+ * Monthly Monarch → Google Sheets asset sync.
+ *
+ * Pulls account balances from Monarch, sums them by type, and writes totals
+ * plus a "last synced" timestamp to the Assets tab of the finance spreadsheet.
+ *
+ * Cell targets (Assets tab):
+ *   B9  — Total Investable (sum of type.name === 'investment')
+ *   B18 — Total Illiquid   (sum of type.name === 'real_estate' || 'other_asset')
+ *   B26 — Last synced timestamp (Pacific)
+ *
+ * Runs monthly via scheduler in src/index.js. Can also be invoked directly
+ * for testing: `node src/jobs/sync-assets.js`.
+ */
+import { getAccounts } from '../utils/monarch.js';
+import { writeValues } from '../utils/sheets.js';
+import log from '../utils/logger.js';
+
+const SPREADSHEET_ID_ENV = 'FINANCE_SPREADSHEET_ID';
+const INVESTABLE_CELL = 'Assets!B9';
+const ILLIQUID_CELL = 'Assets!B18';
+const TIMESTAMP_CELL = 'Assets!B26';
+
+class MonarchAuthError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'MonarchAuthError';
+  }
+}
+
+class SheetsWriteError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'SheetsWriteError';
+  }
+}
+
+function sumByType(accounts, typeNames) {
+  const wanted = new Set(typeNames);
+  let total = 0;
+  for (const acc of accounts) {
+    const typeName = acc?.type?.name;
+    if (wanted.has(typeName)) {
+      const balance = Number(acc.currentBalance ?? 0);
+      if (Number.isFinite(balance)) total += balance;
+    }
+  }
+  return total;
+}
+
+function pacificTimestamp() {
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Los_Angeles',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(new Date()) + ' (Pacific)';
+}
+
+async function notifyLee(message) {
+  try {
+    const { getHousehold } = await import('../utils/config.js');
+    const { sendMessage } = await import('../broker/signal.js');
+    const h = getHousehold();
+    const lee = h?.members?.lee;
+    if (lee?.identifiers?.signal) {
+      sendMessage(lee.identifiers.signal, message);
+    } else {
+      log.warn('Asset sync: cannot notify Lee — Signal identifier missing');
+    }
+  } catch (e) {
+    log.error('Asset sync: notifier failed', { error: e.message });
+  }
+}
+
+/**
+ * Run the sync. Never throws — all errors are logged and (for auth/write
+ * failures) Lee is alerted via Signal.
+ * @returns {Promise<{ok: boolean, totalInvestable?: number, totalIlliquid?: number, error?: string}>}
+ */
+export async function syncAssets() {
+  const spreadsheetId = process.env[SPREADSHEET_ID_ENV]?.trim();
+  if (!spreadsheetId) {
+    log.warn(`Asset sync skipped: ${SPREADSHEET_ID_ENV} not set`);
+    return { ok: false, error: `${SPREADSHEET_ID_ENV} not set` };
+  }
+
+  try {
+    // 1. Pull accounts from Monarch.
+    let accounts;
+    try {
+      accounts = await getAccounts();
+    } catch (err) {
+      throw new MonarchAuthError(err.message);
+    }
+    if (accounts === 'UNAUTHORIZED') {
+      throw new MonarchAuthError('Monarch returned UNAUTHORIZED after retry');
+    }
+    if (!Array.isArray(accounts)) {
+      throw new MonarchAuthError('Monarch getAccounts did not return an array');
+    }
+
+    // 2. Sum by type.
+    const totalInvestable = sumByType(accounts, ['investment']);
+    const totalIlliquid = sumByType(accounts, ['real_estate', 'other_asset']);
+    const timestamp = pacificTimestamp();
+
+    log.info('Asset sync: computed totals', {
+      accountCount: accounts.length,
+      totalInvestable,
+      totalIlliquid,
+    });
+
+    // 3. Write to Sheets.
+    try {
+      await writeValues(spreadsheetId, INVESTABLE_CELL, [[totalInvestable]]);
+      await writeValues(spreadsheetId, ILLIQUID_CELL, [[totalIlliquid]]);
+      await writeValues(spreadsheetId, TIMESTAMP_CELL, [[timestamp]]);
+    } catch (err) {
+      throw new SheetsWriteError(err.message);
+    }
+
+    log.info('Asset sync: complete', { totalInvestable, totalIlliquid, timestamp });
+    return { ok: true, totalInvestable, totalIlliquid };
+  } catch (err) {
+    if (err instanceof MonarchAuthError) {
+      log.error('Asset sync: Monarch auth failed', { error: err.message });
+      await notifyLee('Asset sync failed: Monarch authentication error.');
+      return { ok: false, error: err.message };
+    }
+    if (err instanceof SheetsWriteError) {
+      log.error('Asset sync: Sheets write failed', { error: err.message });
+      await notifyLee('Asset sync failed: Could not write to Google Sheets.');
+      return { ok: false, error: err.message };
+    }
+    // Anything else — log but don't let it escape.
+    log.error('Asset sync: unexpected error', { error: err.message, stack: err.stack });
+    return { ok: false, error: err.message };
+  }
+}
+
+// Pacific "is it the 1st at 6am" scheduler. Follows the setInterval +
+// dedupe pattern used by morning-briefing.js, avoiding a node-cron dep.
+const CHECK_INTERVAL_MS = 60 * 1000; // 1 minute
+const ranThisMonth = new Set();
+
+function pacificMonthKey() {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Los_Angeles',
+    year: 'numeric',
+    month: '2-digit',
+  }).format(new Date()); // e.g. "2026-04"
+}
+
+function pacificParts() {
+  const d = new Date();
+  const day = Number(
+    new Intl.DateTimeFormat('en-US', {
+      timeZone: 'America/Los_Angeles',
+      day: 'numeric',
+    }).format(d)
+  );
+  const hour = Number(
+    new Intl.DateTimeFormat('en-US', {
+      timeZone: 'America/Los_Angeles',
+      hour: 'numeric',
+      hour12: false,
+    }).format(d)
+  );
+  return { day, hour };
+}
+
+async function monthlyTick() {
+  const { day, hour } = pacificParts();
+  if (day !== 1 || hour < 6) return;
+  const key = pacificMonthKey();
+  if (ranThisMonth.has(key)) return;
+  ranThisMonth.add(key);
+  log.info('Asset sync: monthly trigger firing', { month: key });
+  await syncAssets();
+}
+
+/**
+ * Start the monthly scheduler. Also runs once at startup (after a short delay)
+ * so the sheet is populated immediately on first deploy without waiting a
+ * full month. Safe to call multiple times — setInterval will reschedule but
+ * dedupe via ranThisMonth prevents duplicate monthly runs.
+ */
+export function startAssetSyncScheduler({ startupDelayMs = 30_000 } = {}) {
+  setTimeout(() => {
+    log.info('Asset sync: startup run');
+    syncAssets().catch((e) =>
+      log.error('Asset sync: startup run threw', { error: e.message })
+    );
+  }, startupDelayMs);
+
+  setInterval(monthlyTick, CHECK_INTERVAL_MS);
+}
+
+// Direct invocation for testing: `node src/jobs/sync-assets.js`
+// import.meta.url check — only run if this file is the entry point.
+const isDirectRun =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith('sync-assets.js');
+if (isDirectRun) {
+  // eslint-disable-next-line no-console
+  console.log('Running asset sync directly...');
+  syncAssets()
+    .then((result) => {
+      // eslint-disable-next-line no-console
+      console.log('Result:', JSON.stringify(result, null, 2));
+      process.exit(result.ok ? 0 : 1);
+    })
+    .catch((err) => {
+      // eslint-disable-next-line no-console
+      console.error('Fatal:', err);
+      process.exit(1);
+    });
+}

--- a/src/utils/google-oauth.js
+++ b/src/utils/google-oauth.js
@@ -21,8 +21,12 @@ export const DRIVE_SCOPES = [
   'https://www.googleapis.com/auth/documents.readonly',
 ];
 
-// Combined scope set used for initial auth — grants both Gmail and Drive access.
-export const ALL_GOOGLE_SCOPES = [...GMAIL_SCOPES, ...DRIVE_SCOPES];
+export const SHEETS_SCOPES = [
+  'https://www.googleapis.com/auth/spreadsheets',
+];
+
+// Combined scope set used for initial auth — grants Gmail, Drive, and Sheets access.
+export const ALL_GOOGLE_SCOPES = [...GMAIL_SCOPES, ...DRIVE_SCOPES, ...SHEETS_SCOPES];
 
 const REDIRECT_URI_OOB = 'urn:ietf:wg:oauth:2.0:oob';
 

--- a/src/utils/sheets.js
+++ b/src/utils/sheets.js
@@ -1,0 +1,70 @@
+/**
+ * Google Sheets v4 writer. Reuses the per-user OAuth infrastructure in google-oauth.js.
+ * Sheets writes are always performed on behalf of a specific household member whose
+ * OAuth refresh token has been authorized for the SHEETS scope (default: lee).
+ */
+import { getClient, SHEETS_SCOPES } from './google-oauth.js';
+import log from './logger.js';
+
+let cachedSheetsClient = null;
+let cachedPerson = null;
+
+async function getSheetsClient(personId) {
+  if (cachedSheetsClient && cachedPerson === personId) return cachedSheetsClient;
+
+  const authClient = await getClient(personId, SHEETS_SCOPES);
+  if (!authClient) {
+    throw new Error(
+      `No Google OAuth token for "${personId}". Re-authorize with the spreadsheets scope.`
+    );
+  }
+
+  const { google } = await import('googleapis');
+  cachedSheetsClient = google.sheets({ version: 'v4', auth: authClient });
+  cachedPerson = personId;
+  return cachedSheetsClient;
+}
+
+/**
+ * Write values to a spreadsheet range using USER_ENTERED input mode (so
+ * strings like "$1,234" parse as numbers and timestamps parse as dates).
+ *
+ * @param {string} spreadsheetId
+ * @param {string} range - A1 notation, e.g. "Assets!B9"
+ * @param {Array<Array<any>>} values - 2D array of cell values
+ * @param {string} [personId='lee'] - household member whose OAuth token to use
+ * @returns {Promise<object>} the API response data
+ */
+export async function writeValues(spreadsheetId, range, values, personId = 'lee') {
+  if (!spreadsheetId) throw new Error('writeValues: spreadsheetId is required');
+  if (!range) throw new Error('writeValues: range is required');
+  if (!Array.isArray(values) || !Array.isArray(values[0])) {
+    throw new Error('writeValues: values must be a 2D array');
+  }
+
+  const sheets = await getSheetsClient(personId);
+  try {
+    const res = await sheets.spreadsheets.values.update({
+      spreadsheetId,
+      range,
+      valueInputOption: 'USER_ENTERED',
+      requestBody: { values },
+    });
+    log.info('Sheets write ok', {
+      spreadsheetId,
+      range,
+      updatedCells: res.data?.updatedCells,
+    });
+    return res.data;
+  } catch (err) {
+    // Reset the cached client so a stale/revoked auth gets refreshed next call.
+    cachedSheetsClient = null;
+    cachedPerson = null;
+    log.error('Sheets write failed', {
+      spreadsheetId,
+      range,
+      error: err.message,
+    });
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a monthly background job that pulls asset balances from Monarch, sums them by type, and writes totals to the Assets tab of the family finance spreadsheet. The Inputs tab's `Current Portfolio Value` references `Assets!B9`, so this keeps the model fresh without manual updates.

- New `src/utils/sheets.js` — Google Sheets v4 wrapper reusing per-user OAuth infrastructure
- New `src/jobs/sync-assets.js` — sync job + `setInterval`-based monthly scheduler (no new deps), with distinct Signal alerts for Monarch vs Sheets failures
- `src/utils/google-oauth.js` — adds `SHEETS_SCOPES` to `ALL_GOOGLE_SCOPES`
- `src/index.js` — registers scheduler only when `FINANCE_SPREADSHEET_ID` is set
- Spec + verify doc at `specs/finances/ASSET-SYNC.{md,verify.md}` per DEV-PROTOCOL

## Design Notes

- **OAuth not service account** — finance model is Lee's personal sheet, reusing existing per-user OAuth avoids sharing the sheet with a new principal.
- **`setInterval`, not `node-cron`** — follows the house pattern (`morning-briefing.js`, `daily-ops.js`). Monthly check fires at day=1, hour≥6 Pacific, deduped by YYYY-MM.
- **Startup run (30s delay)** — exercises the full path on every deploy so bugs surface immediately, not 30 days later.
- **Separate error classes** — `MonarchAuthError` vs `SheetsWriteError` route to different Signal messages so Lee knows which credential to fix.

## Deviation from the spec worth noting

Spec wording said "accounts where `type === 'investment'`" but Monarch's GraphQL returns `type: { name, display }`. I used `acc.type.name === 'investment'`. Same for `'real_estate'` / `'other_asset'`. Verified against `GET_ACCOUNTS_QUERY` in `src/utils/monarch.js:222`.

## Test plan

- [x] `npm test` — all 584 existing tests pass locally on the branch
- [x] `node --check` on all 4 touched source files
- [x] ESM import resolution smoke test — both new modules load and export the expected symbols
- [ ] **On EC2:** Add `FINANCE_SPREADSHEET_ID=193JJvxdWw_Y9k0oBAyDmku43OEkncj0T8DX8htVWVfo` to `.env`
- [ ] **Lee's fingers:** Re-authorize Google OAuth to grant the new `spreadsheets` scope (existing token lacks it)
- [ ] **On EC2:** Confirm Assets tab B9/B18/B26 row positions match the live sheet before first run
- [ ] **On EC2:** `node src/jobs/sync-assets.js` — direct invocation smoke test, expect exit 0 and three `Sheets write ok` log lines
- [ ] **On EC2:** Restart `iji.service`, wait 60s, confirm `journalctl` shows "Asset sync: startup run" → "Asset sync: complete"
- [ ] Open the sheet and verify B9, B18, B26 are populated; confirm `Inputs!Current Portfolio Value` updated
- [ ] Kill Monarch session → confirm Signal alert fires
- [ ] Clobber Lee's OAuth token → confirm different Signal alert fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)